### PR TITLE
launch videoIdent on the main thread instead of a background thread

### DIFF
--- a/ios/ReactNativeIdnowVideoident.m
+++ b/ios/ReactNativeIdnowVideoident.m
@@ -19,9 +19,17 @@ RCT_EXPORT_MODULE()
 
 // Example method
 // See // https://reactnative.dev/docs/native-modules-ios
-RCT_EXPORT_METHOD(startVideoIdent : (NSDictionary *)settings successCallback : (RCTResponseSenderBlock)successCallback errorCallback : (RCTResponseSenderBlock)errorCallback) {
-	idnowViewController = [[IdnowViewController alloc] initializeWithSettings:settings];
-	[idnowViewController startVideoIdent:errorCallback successCallback:successCallback];
+RCT_EXPORT_METHOD(startVideoIdent: (NSDictionary *)settings
+                  successCallback: (RCTResponseSenderBlock)successCallback
+                  errorCallback: (RCTResponseSenderBlock)errorCallback) {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            strongSelf->idnowViewController = [[IdnowViewController alloc] initializeWithSettings:settings];
+            [strongSelf->idnowViewController startVideoIdent:errorCallback successCallback:successCallback];
+        }
+    });
 }
 
 @end


### PR DESCRIPTION
For me the app would crash because some calls are supposed to run on the main thread, which makes sense for UI.

I think I will need to do a few more PRs. Are you still maintaining this and do want more PRs or should I just fork it and call it a day?
